### PR TITLE
Turbo builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>surefire-cached-extension</module>
         <module>surefire-cached-maven-plugin</module>
         <module>test-cache-server</module>
+        <module>turbo-builder</module>
     </modules>
 
     <build>

--- a/turbo-builder/pom.xml
+++ b/turbo-builder/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.seregamorph</groupId>
+        <artifactId>maven-surefire-cached</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>turbo-builder</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/SignalingExecutorCompletionService.java
+++ b/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/SignalingExecutorCompletionService.java
@@ -1,0 +1,88 @@
+package com.github.seregamorph.maven.test.builder;
+
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.apache.maven.project.MavenProject;
+
+class SignalingExecutorCompletionService {
+
+    private static final ThreadLocal<Consumer<MavenProject>> currentSignaler = new ThreadLocal<>();
+
+    private final ExecutorService executor;
+    private final BlockingQueue<Try<MavenProject>> signaledQueue;
+
+    SignalingExecutorCompletionService(ExecutorService executor) {
+        this.executor = Objects.requireNonNull(executor);
+        this.signaledQueue = new LinkedBlockingQueue<>();
+    }
+
+    static void signal(MavenProject value) {
+        Consumer<MavenProject> signaler = currentSignaler.get();
+        if (signaler != null) {
+            signaler.accept(value);
+        }
+    }
+
+    Future<?> submit(Callable<MavenProject> call) {
+        Objects.requireNonNull(call);
+        return executor.submit(new FutureTask<>(() -> {
+            AtomicBoolean signaled = new AtomicBoolean(false);
+            currentSignaler.set(value -> {
+                // no race condition here with "if (!signaled.get())" block, because it's the same thread
+                signaled.set(true);
+                signaledQueue.add(Try.success(value));
+            });
+            try {
+                MavenProject result = call.call();
+                if (!signaled.get()) {
+                    signaledQueue.add(Try.success(result));
+                }
+                return result;
+            } catch (Throwable e) {
+                signaledQueue.add(Try.failure(e));
+                if (e instanceof Exception) {
+                    throw e;
+                } else {
+                    throw new RuntimeException(e);
+                }
+            } finally {
+                currentSignaler.remove();
+            }
+        }));
+    }
+
+    public MavenProject takeSignaled() throws InterruptedException, ExecutionException {
+        Try<MavenProject> t = signaledQueue.take();
+        return t.get();
+    }
+
+    private abstract static class Try<T> {
+        abstract T get() throws ExecutionException;
+
+        static <T> Try<T> success(T value) {
+            return new Try<T>() {
+                @Override
+                T get() {
+                    return value;
+                }
+            };
+        }
+
+        static <T> Try<T> failure(Throwable e) {
+            return new Try<>() {
+                @Override
+                T get() throws ExecutionException {
+                    throw new ExecutionException(e);
+                }
+            };
+        }
+    }
+}

--- a/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/TurboBuilder.java
+++ b/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/TurboBuilder.java
@@ -1,0 +1,183 @@
+package com.github.seregamorph.maven.test.builder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.internal.BuildThreadFactory;
+import org.apache.maven.lifecycle.internal.LifecycleModuleBuilder;
+import org.apache.maven.lifecycle.internal.ProjectBuildList;
+import org.apache.maven.lifecycle.internal.ProjectSegment;
+import org.apache.maven.lifecycle.internal.ReactorBuildStatus;
+import org.apache.maven.lifecycle.internal.ReactorContext;
+import org.apache.maven.lifecycle.internal.TaskSegment;
+import org.apache.maven.lifecycle.internal.builder.Builder;
+import org.apache.maven.lifecycle.internal.builder.multithreaded.ConcurrencyDependencyGraph;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
+
+@Singleton
+@Named("turbo")
+public class TurboBuilder implements Builder {
+
+    private final LifecycleModuleBuilder lifecycleModuleBuilder;
+    private final Logger logger;
+
+    @Inject
+    public TurboBuilder(LifecycleModuleBuilder lifecycleModuleBuilder, Logger logger) {
+        this.lifecycleModuleBuilder = lifecycleModuleBuilder;
+        this.logger = logger;
+    }
+
+    @Override
+    public void build(
+        MavenSession session,
+        ReactorContext reactorContext,
+        ProjectBuildList projectBuilds,
+        List<TaskSegment> taskSegments,
+        ReactorBuildStatus reactorBuildStatus
+    ) throws InterruptedException {
+        int nThreads = Math.min(
+            session.getRequest().getDegreeOfConcurrency(),
+            session.getProjects().size());
+        boolean parallel = nThreads > 1;
+        // Propagate the parallel flag to the root session and all of the cloned sessions in each project segment
+        session.setParallel(parallel);
+        for (ProjectSegment segment : projectBuilds) {
+            segment.getSession().setParallel(parallel);
+        }
+        ExecutorService executor = Executors.newFixedThreadPool(nThreads, new BuildThreadFactory());
+        SignalingExecutorCompletionService service = new SignalingExecutorCompletionService(executor);
+
+        for (TaskSegment taskSegment : taskSegments) {
+            ProjectBuildList segmentProjectBuilds = projectBuilds.getByTaskSegment(taskSegment);
+            Map<MavenProject, ProjectSegment> projectBuildMap = projectBuilds.selectSegment(taskSegment);
+            try {
+                ConcurrencyDependencyGraph analyzer =
+                    new ConcurrencyDependencyGraph(segmentProjectBuilds, session.getProjectDependencyGraph());
+                multiThreadedProjectTaskSegmentBuild(
+                    analyzer, reactorContext, session, service, taskSegment, projectBuildMap);
+                if (reactorContext.getReactorBuildStatus().isHalted()) {
+                    break;
+                }
+            } catch (Exception e) {
+                session.getResult().addException(e);
+                break;
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+    }
+
+    private void multiThreadedProjectTaskSegmentBuild(
+        ConcurrencyDependencyGraph analyzer,
+        ReactorContext reactorContext,
+        MavenSession rootSession,
+        SignalingExecutorCompletionService service,
+        TaskSegment taskSegment,
+        Map<MavenProject, ProjectSegment> projectBuildList
+    ) {
+        // gather artifactIds which are not unique so that the respective thread names can be extended with the groupId
+        Set<String> duplicateArtifactIds = gatherDuplicateArtifactIds(projectBuildList.keySet());
+
+        // collect all submitted tasks to join them at the end
+        List<Future<?>> tasks = new ArrayList<>();
+        // schedule independent projects
+        for (MavenProject mavenProject : analyzer.getRootSchedulableBuilds()) {
+            ProjectSegment projectSegment = projectBuildList.get(mavenProject);
+            logger.debug("Scheduling: " + projectSegment.getProject());
+            Callable<MavenProject> cb = createBuildCallable(
+                rootSession, projectSegment, reactorContext, taskSegment, duplicateArtifactIds);
+            tasks.add(service.submit(cb));
+        }
+
+        // for each finished project
+        for (int i = 0; i < analyzer.getNumberOfBuilds(); i++) {
+            try {
+                MavenProject projectBuild = service.takeSignaled();
+                if (reactorContext.getReactorBuildStatus().isHalted()) {
+                    return;
+                }
+
+                // MNG-6170: Only schedule other modules from reactor if we have more modules to build than one.
+                if (analyzer.getNumberOfBuilds() > 1) {
+                    List<MavenProject> newItemsThatCanBeBuilt = analyzer.markAsFinished(projectBuild);
+                    for (MavenProject mavenProject : newItemsThatCanBeBuilt) {
+                        ProjectSegment scheduledDependent = projectBuildList.get(mavenProject);
+                        logger.debug("Scheduling: " + scheduledDependent);
+                        Callable<MavenProject> cb = createBuildCallable(
+                            rootSession,
+                            scheduledDependent,
+                            reactorContext,
+                            taskSegment,
+                            duplicateArtifactIds);
+                        tasks.add(service.submit(cb));
+                    }
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                rootSession.getResult().addException(e);
+                return;
+            }
+        }
+
+        for (Future<?> task : tasks) {
+            try {
+                task.get();
+            } catch (InterruptedException | ExecutionException e) {
+                rootSession.getResult().addException(e);
+                return;
+            }
+        }
+    }
+
+    private Callable<MavenProject> createBuildCallable(
+        MavenSession rootSession,
+        ProjectSegment projectBuild,
+        ReactorContext reactorContext,
+        TaskSegment taskSegment,
+        Set<String> duplicateArtifactIds
+    ) {
+        return () -> {
+            final Thread currentThread = Thread.currentThread();
+            final String originalThreadName = currentThread.getName();
+            final MavenProject project = projectBuild.getProject();
+
+            final String threadNameSuffix = duplicateArtifactIds.contains(project.getArtifactId())
+                ? project.getGroupId() + ":" + project.getArtifactId()
+                : project.getArtifactId();
+            currentThread.setName("mvn-turbo-builder-" + threadNameSuffix);
+
+            try {
+                lifecycleModuleBuilder.buildProject(
+                    projectBuild.getSession(), rootSession, reactorContext, project, taskSegment);
+
+                return projectBuild.getProject();
+            } finally {
+                currentThread.setName(originalThreadName);
+            }
+        };
+    }
+
+    private Set<String> gatherDuplicateArtifactIds(Set<MavenProject> projects) {
+        Set<String> artifactIds = new HashSet<>(projects.size());
+        Set<String> duplicateArtifactIds = new HashSet<>();
+        for (MavenProject project : projects) {
+            if (!artifactIds.add(project.getArtifactId())) {
+                duplicateArtifactIds.add(project.getArtifactId());
+            }
+        }
+        return duplicateArtifactIds;
+    }
+}

--- a/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/TurboMojosExecutionStrategy.java
+++ b/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/TurboMojosExecutionStrategy.java
@@ -1,0 +1,96 @@
+package com.github.seregamorph.maven.test.builder;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.LifecycleExecutionException;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionRunner;
+import org.apache.maven.plugin.MojosExecutionStrategy;
+import org.eclipse.sisu.Priority;
+
+@Named
+@Singleton
+@Priority(10)
+public class TurboMojosExecutionStrategy implements MojosExecutionStrategy {
+
+/*
+    original phases of the default lifecycle [
+        "validate",
+        "initialize",
+        "generate-sources",
+        "process-sources",
+        "generate-resources",
+        "process-resources",
+        "compile",
+        "process-classes",
+
+        "generate-test-sources",
+        "process-test-sources",
+        "generate-test-resources",
+        "process-test-resources",
+        "test-compile",
+        "process-test-classes",
+        "test",
+
+        // moved before "*test*" phases
+        "prepare-package",
+        "package",
+
+        "pre-integration-test",
+        "integration-test",
+        "post-integration-test",
+        "verify",
+        "install",
+        "deploy"
+    ]
+*/
+
+    private static boolean isPackage(MojoExecution mojo) {
+        return List.of("prepare-package", "package")
+            .contains(mojo.getLifecyclePhase());
+    }
+
+    private static boolean isTest(MojoExecution mojo) {
+        // "generate-test-sources", "process-test-sources", "generate-test-resources", "process-test-resources",
+        // "test-compile", "process-test-classes", "test", "pre-integration-test", "integration-test",
+        // "post-integration-test"
+        return mojo.getLifecyclePhase().contains("test");
+    }
+
+    @Override
+    public void execute(
+        List<MojoExecution> mojos,
+        MavenSession session,
+        MojoExecutionRunner mojoRunner
+    ) throws LifecycleExecutionException {
+        var packageMojos = mojos.stream()
+            .filter(TurboMojosExecutionStrategy::isPackage)
+            .toList();
+        int firstTestMojoIndex = -1;
+        for (int i = 0; i < mojos.size(); i++) {
+            if (isTest(mojos.get(i))) {
+                firstTestMojoIndex = i;
+                break;
+            }
+        }
+        var reorderedMojos = new ArrayList<>(mojos);
+        if (!packageMojos.isEmpty() && firstTestMojoIndex != -1) {
+            reorderedMojos.removeAll(packageMojos);
+            reorderedMojos.addAll(firstTestMojoIndex, packageMojos);
+        }
+
+        var executedPackageMojos = new ArrayList<MojoExecution>();
+        for (MojoExecution mojoExecution : reorderedMojos) {
+            mojoRunner.run(mojoExecution);
+            if (packageMojos.contains(mojoExecution)) {
+                executedPackageMojos.add(mojoExecution);
+                if (packageMojos.equals(executedPackageMojos)) {
+                    SignalingExecutorCompletionService.signal(session.getCurrentProject());
+                }
+            }
+        }
+    }
+}

--- a/turbo-builder/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/turbo-builder/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,2 @@
+com.github.seregamorph.maven.test.builder.TurboBuilder
+com.github.seregamorph.maven.test.builder.TurboMojosExecutionStrategy


### PR DESCRIPTION
To use builder:
Add extension to `.mvn/extensions.xml`
and run build with parameter
```
./mvnw clean package -b turbo
```

Rewrite worker scheduler to make it more efficient.
Brief: instead of waiting for all phases building dependencies we can only wait `package` - this way we increase possible build parallelism:
<img width="658" alt="Screenshot 2025-02-15 at 19 31 15" src="https://github.com/user-attachments/assets/45cf03d6-896c-40f8-b4d1-f49c54b3499a" />

Also it could make sense to change the order of phases to make `package` before `test` (not after):
<img width="437" alt="Screenshot 2025-02-15 at 19 31 28" src="https://github.com/user-attachments/assets/0de125e4-c5a6-48fc-8a6f-65a13099d9d5" />
