### PR TITLE
Turbo Builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <module>surefire-cached-extension</module>
         <module>surefire-cached-maven-plugin</module>
         <module>test-cache-server</module>
+        <module>turbo-builder</module>
+        <module>turbo-builder-maven-plugin</module>
     </modules>
 
     <build>
@@ -108,6 +110,11 @@
             <dependency>
                 <groupId>com.github.seregamorph</groupId>
                 <artifactId>surefire-cached-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.seregamorph</groupId>
+                <artifactId>turbo-builder-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/turbo-builder-maven-plugin/pom.xml
+++ b/turbo-builder-maven-plugin/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.seregamorph</groupId>
+        <artifactId>maven-surefire-cached</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>turbo-builder-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <configuration>
+                    <goalPrefix>turbo-builder</goalPrefix>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/turbo-builder-maven-plugin/src/main/java/com/github/seregamorph/maven/test/builder/SignalMojo.java
+++ b/turbo-builder-maven-plugin/src/main/java/com/github/seregamorph/maven/test/builder/SignalMojo.java
@@ -1,0 +1,33 @@
+package com.github.seregamorph.maven.test.builder;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import java.util.function.Consumer;
+
+@Mojo(
+    name = "signal",
+    defaultPhase = LifecyclePhase.PACKAGE,
+    threadSafe = true)
+public class SignalMojo extends AbstractMojo {
+
+    /**
+     * See {@link com.github.seregamorph.maven.test.builder.SignalingExecutorCompletionService#ATTR_SIGNALER}
+     */
+    private static final String ATTR_SIGNALER = "signaler";
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void execute() {
+        // note: ClassLoader for this class is different in the turbo-builder-maven-plugin and turbo-builder extension
+        Consumer<MavenProject> signaler = (Consumer<MavenProject>) project.getContextValue(ATTR_SIGNALER);
+        if (signaler != null) {
+            signaler.accept(project);
+        }
+    }
+}

--- a/turbo-builder/pom.xml
+++ b/turbo-builder/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.seregamorph</groupId>
+        <artifactId>maven-surefire-cached</artifactId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>turbo-builder</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/SignalingExecutorCompletionService.java
+++ b/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/SignalingExecutorCompletionService.java
@@ -1,0 +1,82 @@
+package com.github.seregamorph.maven.test.builder;
+
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.apache.maven.project.MavenProject;
+
+class SignalingExecutorCompletionService {
+
+    /**
+     * See {@link com.github.seregamorph.maven.test.builder.SignalMojo#ATTR_SIGNALER}
+     */
+    private static final String ATTR_SIGNALER = "signaler";
+
+    private final ExecutorService executor;
+    private final BlockingQueue<Try<MavenProject>> signaledQueue;
+
+    SignalingExecutorCompletionService(ExecutorService executor) {
+        this.executor = Objects.requireNonNull(executor);
+        this.signaledQueue = new LinkedBlockingQueue<>();
+    }
+
+    Future<?> submit(MavenProject project, Callable<MavenProject> call) {
+        Objects.requireNonNull(call);
+        return executor.submit(new FutureTask<>(() -> {
+            AtomicBoolean signaled = new AtomicBoolean(false);
+            project.setContextValue(ATTR_SIGNALER, (Consumer<MavenProject>) $ ->{
+                // no race condition here with "if (!signaled.get())" block, because it's the same thread
+                signaled.set(true);
+                signaledQueue.add(Try.success(project));
+            });
+            try {
+                MavenProject result = call.call();
+                if (!signaled.get()) {
+                    signaledQueue.add(Try.success(result));
+                }
+                return result;
+            } catch (Throwable e) {
+                signaledQueue.add(Try.failure(e));
+                if (e instanceof Exception) {
+                    throw e;
+                } else {
+                    throw new RuntimeException(e);
+                }
+            }
+        }));
+    }
+
+    public MavenProject takeSignaled() throws InterruptedException, ExecutionException {
+        Try<MavenProject> t = signaledQueue.take();
+        return t.get();
+    }
+
+    private abstract static class Try<T> {
+        abstract T get() throws ExecutionException;
+
+        static <T> Try<T> success(T value) {
+            return new Try<T>() {
+                @Override
+                T get() {
+                    return value;
+                }
+            };
+        }
+
+        static <T> Try<T> failure(Throwable e) {
+            return new Try<>() {
+                @Override
+                T get() throws ExecutionException {
+                    throw new ExecutionException(e);
+                }
+            };
+        }
+    }
+}

--- a/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/TurboBuilder.java
+++ b/turbo-builder/src/main/java/com/github/seregamorph/maven/test/builder/TurboBuilder.java
@@ -1,0 +1,183 @@
+package com.github.seregamorph.maven.test.builder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.lifecycle.internal.BuildThreadFactory;
+import org.apache.maven.lifecycle.internal.LifecycleModuleBuilder;
+import org.apache.maven.lifecycle.internal.ProjectBuildList;
+import org.apache.maven.lifecycle.internal.ProjectSegment;
+import org.apache.maven.lifecycle.internal.ReactorBuildStatus;
+import org.apache.maven.lifecycle.internal.ReactorContext;
+import org.apache.maven.lifecycle.internal.TaskSegment;
+import org.apache.maven.lifecycle.internal.builder.Builder;
+import org.apache.maven.lifecycle.internal.builder.multithreaded.ConcurrencyDependencyGraph;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.logging.Logger;
+
+@Singleton
+@Named("turbo")
+public class TurboBuilder implements Builder {
+
+    private final LifecycleModuleBuilder lifecycleModuleBuilder;
+    private final Logger logger;
+
+    @Inject
+    public TurboBuilder(LifecycleModuleBuilder lifecycleModuleBuilder, Logger logger) {
+        this.lifecycleModuleBuilder = lifecycleModuleBuilder;
+        this.logger = logger;
+    }
+
+    @Override
+    public void build(
+        MavenSession session,
+        ReactorContext reactorContext,
+        ProjectBuildList projectBuilds,
+        List<TaskSegment> taskSegments,
+        ReactorBuildStatus reactorBuildStatus
+    ) throws InterruptedException {
+        int nThreads = Math.min(
+            session.getRequest().getDegreeOfConcurrency(),
+            session.getProjects().size());
+        boolean parallel = nThreads > 1;
+        // Propagate the parallel flag to the root session and all of the cloned sessions in each project segment
+        session.setParallel(parallel);
+        for (ProjectSegment segment : projectBuilds) {
+            segment.getSession().setParallel(parallel);
+        }
+        ExecutorService executor = Executors.newFixedThreadPool(nThreads, new BuildThreadFactory());
+        SignalingExecutorCompletionService service = new SignalingExecutorCompletionService(executor);
+
+        for (TaskSegment taskSegment : taskSegments) {
+            ProjectBuildList segmentProjectBuilds = projectBuilds.getByTaskSegment(taskSegment);
+            Map<MavenProject, ProjectSegment> projectBuildMap = projectBuilds.selectSegment(taskSegment);
+            try {
+                ConcurrencyDependencyGraph analyzer =
+                    new ConcurrencyDependencyGraph(segmentProjectBuilds, session.getProjectDependencyGraph());
+                multiThreadedProjectTaskSegmentBuild(
+                    analyzer, reactorContext, session, service, taskSegment, projectBuildMap);
+                if (reactorContext.getReactorBuildStatus().isHalted()) {
+                    break;
+                }
+            } catch (Exception e) {
+                session.getResult().addException(e);
+                break;
+            }
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+    }
+
+    private void multiThreadedProjectTaskSegmentBuild(
+        ConcurrencyDependencyGraph analyzer,
+        ReactorContext reactorContext,
+        MavenSession rootSession,
+        SignalingExecutorCompletionService service,
+        TaskSegment taskSegment,
+        Map<MavenProject, ProjectSegment> projectBuildList
+    ) {
+        // gather artifactIds which are not unique so that the respective thread names can be extended with the groupId
+        Set<String> duplicateArtifactIds = gatherDuplicateArtifactIds(projectBuildList.keySet());
+
+        // collect all submitted tasks to join them at the end
+        List<Future<?>> tasks = new ArrayList<>();
+        // schedule independent projects
+        for (MavenProject mavenProject : analyzer.getRootSchedulableBuilds()) {
+            ProjectSegment projectSegment = projectBuildList.get(mavenProject);
+            logger.debug("Scheduling: " + projectSegment.getProject());
+            Callable<MavenProject> cb = createBuildCallable(
+                rootSession, projectSegment, reactorContext, taskSegment, duplicateArtifactIds);
+            tasks.add(service.submit(mavenProject, cb));
+        }
+
+        // for each finished project
+        for (int i = 0; i < analyzer.getNumberOfBuilds(); i++) {
+            try {
+                MavenProject projectBuild = service.takeSignaled();
+                if (reactorContext.getReactorBuildStatus().isHalted()) {
+                    return;
+                }
+
+                // MNG-6170: Only schedule other modules from reactor if we have more modules to build than one.
+                if (analyzer.getNumberOfBuilds() > 1) {
+                    List<MavenProject> newItemsThatCanBeBuilt = analyzer.markAsFinished(projectBuild);
+                    for (MavenProject mavenProject : newItemsThatCanBeBuilt) {
+                        ProjectSegment scheduledDependent = projectBuildList.get(mavenProject);
+                        logger.debug("Scheduling: " + scheduledDependent);
+                        Callable<MavenProject> cb = createBuildCallable(
+                            rootSession,
+                            scheduledDependent,
+                            reactorContext,
+                            taskSegment,
+                            duplicateArtifactIds);
+                        tasks.add(service.submit(mavenProject, cb));
+                    }
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                rootSession.getResult().addException(e);
+                return;
+            }
+        }
+
+        for (Future<?> task : tasks) {
+            try {
+                task.get();
+            } catch (InterruptedException | ExecutionException e) {
+                rootSession.getResult().addException(e);
+                return;
+            }
+        }
+    }
+
+    private Callable<MavenProject> createBuildCallable(
+        MavenSession rootSession,
+        ProjectSegment projectBuild,
+        ReactorContext reactorContext,
+        TaskSegment taskSegment,
+        Set<String> duplicateArtifactIds
+    ) {
+        return () -> {
+            final Thread currentThread = Thread.currentThread();
+            final String originalThreadName = currentThread.getName();
+            final MavenProject project = projectBuild.getProject();
+
+            final String threadNameSuffix = duplicateArtifactIds.contains(project.getArtifactId())
+                ? project.getGroupId() + ":" + project.getArtifactId()
+                : project.getArtifactId();
+            currentThread.setName("mvn-turbo-builder-" + threadNameSuffix);
+
+            try {
+                lifecycleModuleBuilder.buildProject(
+                    projectBuild.getSession(), rootSession, reactorContext, project, taskSegment);
+
+                return projectBuild.getProject();
+            } finally {
+                currentThread.setName(originalThreadName);
+            }
+        };
+    }
+
+    private Set<String> gatherDuplicateArtifactIds(Set<MavenProject> projects) {
+        Set<String> artifactIds = new HashSet<>(projects.size());
+        Set<String> duplicateArtifactIds = new HashSet<>();
+        for (MavenProject project : projects) {
+            if (!artifactIds.add(project.getArtifactId())) {
+                duplicateArtifactIds.add(project.getArtifactId());
+            }
+        }
+        return duplicateArtifactIds;
+    }
+}

--- a/turbo-builder/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/turbo-builder/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,1 @@
+com.github.seregamorph.maven.test.builder.TurboBuilder


### PR DESCRIPTION
Enhance parallelization via running `surefire:test` later in `pre-integration-test` phase (instead of default `test` phase) and signaling right after the `package:jar` to the Builder that downstream dependencies are ready to consume this module JAR.