### PR TITLE
test-module-skip-extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <module>surefire-cached-common</module>
         <module>surefire-cached-extension</module>
         <module>test-cache-server</module>
+        <module>test-module-skip-extension</module>
         <module>turbo-builder</module>
     </modules>
 

--- a/test-module-skip-extension/pom.xml
+++ b/test-module-skip-extension/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.seregamorph</groupId>
+        <artifactId>maven-surefire-cached</artifactId>
+        <version>0.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>test-module-skip-extension</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/test-module-skip-extension/src/main/java/com/github/seregamorph/maven/test/extension/TestModuleSkipLifecycleParticipant.java
+++ b/test-module-skip-extension/src/main/java/com/github/seregamorph/maven/test/extension/TestModuleSkipLifecycleParticipant.java
@@ -1,0 +1,75 @@
+package com.github.seregamorph.maven.test.extension;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.SessionScoped;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.inject.Named;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Listener that cleans up test modules from the session to speed up the build.
+ *
+ * @author Sergey Chernov
+ */
+@SessionScoped
+@Named
+public class TestModuleSkipLifecycleParticipant extends AbstractMavenLifecycleParticipant {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestModuleSkipLifecycleParticipant.class);
+
+    @Override
+    public void afterProjectsRead(MavenSession session) {
+        String testModuleSkip = session.getUserProperties().getProperty("testModuleSkip");
+        if ("true".equals(testModuleSkip)) {
+            logger.info("test-module-skip-extension: cleaning up projects (total projects {})", session.getProjects().size());
+            var removedModules = new TreeSet<String>();
+            session.getProjects().removeIf(mavenProject -> {
+                if (isTestModule(mavenProject)) {
+                    removedModules.add(mavenProject.getGroupId() + ':' + mavenProject.getArtifactId());
+                    return true;
+                } else {
+                    return false;
+                }
+            });
+            AtomicInteger removedTestDependenciesCount = new AtomicInteger();
+            AtomicInteger removedTestDependenciesAffectedProjectsCount = new AtomicInteger();
+            session.getProjects().forEach(project -> {
+                if (project.getDependencies().removeIf(dependency -> {
+                    if ("test".equals(dependency.getScope())) {
+                        removedTestDependenciesCount.incrementAndGet();
+                        return true;
+                    } else {
+                        return false;
+                    }
+                })) {
+                    removedTestDependenciesAffectedProjectsCount.incrementAndGet();
+                };
+            });
+            if (removedModules.isEmpty()) {
+                logger.info("No test modules found");
+            } else {
+                logger.info("Removed {} test modules: {}", removedModules.size(), removedModules);
+            }
+            if (removedTestDependenciesCount.get() == 0) {
+                logger.info("No test dependencies found");
+            } else {
+                logger.info("Removed {} test scope dependencies from {} projects",
+                    removedTestDependenciesCount.get(), removedTestDependenciesAffectedProjectsCount.get());
+            }
+        }
+    }
+
+    private static boolean isTestModule(MavenProject project) {
+        return "jar".equals(project.getPackaging())
+            && ("testing".equals(project.getArtifactId())
+            || project.getArtifactId().endsWith("-testing")
+            || project.getArtifactId().endsWith("-test")
+            || project.getArtifactId().contains("-test-")
+            || project.getArtifactId().endsWith("-tests")
+        );
+    }
+}

--- a/test-module-skip-extension/src/main/resources/META-INF/sisu/javax.inject.Named
+++ b/test-module-skip-extension/src/main/resources/META-INF/sisu/javax.inject.Named
@@ -1,0 +1,1 @@
+com.github.seregamorph.maven.test.extension.TestModuleSkipLifecycleParticipant


### PR DESCRIPTION
This extension removes all test modules (containing the `testing`,  `test` or `tests` in the artifactId) from the build graph. This speeds up the build.