### PR TITLE
Output artifact detailed metadata

### DIFF
--- a/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/OutputArtifact.java
+++ b/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/OutputArtifact.java
@@ -1,0 +1,15 @@
+package com.github.seregamorph.maven.test.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author Sergey Chernov
+ */
+@JsonIgnoreProperties(ignoreUnknown = true) // for forward compatibility
+public record OutputArtifact(
+    String fileName,
+    int files,
+    long unpackedSize,
+    long packedSize
+) {
+}

--- a/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/TestTaskOutput.java
+++ b/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/TestTaskOutput.java
@@ -1,5 +1,6 @@
 package com.github.seregamorph.maven.test.common;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Map;
@@ -7,6 +8,7 @@ import java.util.Map;
 /**
  * @author Sergey Chernov
  */
+@JsonIgnoreProperties(ignoreUnknown = true) // for forward compatibility
 public record TestTaskOutput(
     Instant startTime,
     Instant endTime,
@@ -23,8 +25,7 @@ public record TestTaskOutput(
     int totalTests,
     int totalErrors,
     int totalFailures,
-    // alias -> packed target name
-    Map<String, String> files
+    // alias -> artifact
+    Map<String, OutputArtifact> artifacts
 ) {
-
 }

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/core/TestTaskInput.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/core/TestTaskInput.java
@@ -46,7 +46,7 @@ public final class TestTaskInput {
     /**
      * Updated on each breaking change
      */
-    private static final int VERSION = 1;
+    private static final int VERSION = 2;
 
     private String hash;
 

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/util/ZipUtils.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/util/ZipUtils.java
@@ -25,14 +25,19 @@ import org.apache.commons.io.IOUtils;
  */
 public final class ZipUtils {
 
+    public record PackedFile(String fileName, long unpackedSize) {
+    }
+
     /**
      * Pack directory filtered included files to TAR.GZ
      *
      * @param directory
      * @param includes
      * @param packFile  target tar.gz file
+     * @return packed files info
      */
-    public static void packDirectory(File directory, List<String> includes, File packFile) {
+    public static List<PackedFile> packDirectory(File directory, List<String> includes, File packFile) {
+        var packedFiles = new ArrayList<PackedFile>();
         try (OutputStream fos = new FileOutputStream(packFile);
              BufferedOutputStream bos = new BufferedOutputStream(fos);
              GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
@@ -52,11 +57,13 @@ public final class ZipUtils {
                         IOUtils.copy(fis, taos);
                     }
                     taos.closeArchiveEntry();
+                    packedFiles.add(new PackedFile(fileName, file.length()));
                 }
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+        return packedFiles;
     }
 
     public static void unpackDirectory(File packFile, File targetDirectory) {


### PR DESCRIPTION
Add more details about cached entity artifacts.

*This is a breaking change*

Unfortunately, there were no forward compatibility to parse `TestTaskOutput`. Now there will be `@JsonIgnoreProperties(ignoreUnknown = true)` for further updates of the structure.
This means, that the server should be updated before the maven extension.