### PR TITLE
Check minServerVersion via HTTP header

### DIFF
--- a/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/ServerProtocolVersion.java
+++ b/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/ServerProtocolVersion.java
@@ -1,0 +1,18 @@
+package com.github.seregamorph.maven.test.common;
+
+/**
+ * @author Sergey Chernov
+ */
+public final class ServerProtocolVersion {
+
+    public static final int SERVER_PROTOCOL_VERSION = 1;
+    /**
+     * Each time when the server has a breaking change, this should be increased
+     */
+    public static final int MIN_SERVER_PROTOCOL_VERSION = 1;
+
+    public static final String HEADER_SERVER_PROTOCOL_VERSION =  "Server-Protocol-Version";
+
+    private ServerProtocolVersion() {
+    }
+}

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/CacheStorageFactory.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/CacheStorageFactory.java
@@ -6,6 +6,7 @@ import com.github.seregamorph.maven.test.storage.HttpCacheStorage;
 import com.github.seregamorph.maven.test.storage.HttpCacheStorageConfig;
 import java.io.File;
 import java.net.URI;
+import java.time.Duration;
 import org.apache.maven.execution.MavenSession;
 
 /**
@@ -15,21 +16,25 @@ class CacheStorageFactory {
 
     private static final String PROP_CACHE_STORAGE_URL = "cacheStorageUrl";
 
-    static CacheStorage createCacheStorage(MavenSession session) {
+    private final MavenSession session;
+
+    CacheStorageFactory(MavenSession session) {
+        this.session = session;
+    }
+
+    CacheStorage createCacheStorage() {
         String cacheStorageUrl = session.getUserProperties().getProperty(PROP_CACHE_STORAGE_URL);
         if (cacheStorageUrl == null) {
             cacheStorageUrl = System.getProperty("user.home") + "/.m2/test-cache";
         }
         //noinspection HttpUrlsUsage
         if (cacheStorageUrl.startsWith("http://") || cacheStorageUrl.startsWith("https://")) {
-            // todo configuration
-            var httpCacheStorageConfig = new HttpCacheStorageConfig(URI.create(cacheStorageUrl));
+            // todo support custom configuration, auth, etc.
+            var httpCacheStorageConfig = new HttpCacheStorageConfig(URI.create(cacheStorageUrl),
+                true, Duration.ofSeconds(5L), Duration.ofSeconds(10L), Duration.ofSeconds(10L));
             return new HttpCacheStorage(httpCacheStorageConfig);
         }
 
         return new FileCacheStorage(new File(cacheStorageUrl));
-    }
-
-    private CacheStorageFactory() {
     }
 }

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/TestTaskCacheHelper.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/TestTaskCacheHelper.java
@@ -47,8 +47,9 @@ public class TestTaskCacheHelper {
             .collect(Collectors.toCollection(TreeSet::new));
 
         this.metrics = new CacheServiceMetrics();
-        this.cacheStorage = CacheStorageFactory.createCacheStorage(session);
-        this.cacheService = new CacheService(cacheStorage, metrics, 2);
+        this.cacheStorage = new CacheStorageFactory(session).createCacheStorage();
+        // todo configurable failureThreshold
+        this.cacheService = new CacheService(cacheStorage, metrics, 4);
         this.cacheReport = new CacheReport();
     }
 

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/storage/HttpCacheStorageConfig.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/storage/HttpCacheStorageConfig.java
@@ -8,11 +8,9 @@ import java.time.Duration;
  */
 public record HttpCacheStorageConfig(
     URI baseUrl,
+    boolean checkServerVersion,
     Duration connectTimeout,
     Duration readTimeout,
     Duration writeTimeout
 ) {
-    public HttpCacheStorageConfig(URI baseUrl) {
-        this(baseUrl, Duration.ofSeconds(5L), Duration.ofSeconds(10L), Duration.ofSeconds(10L));
-    }
 }

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/storage/MinServerProtocolVersionException.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/storage/MinServerProtocolVersionException.java
@@ -1,0 +1,14 @@
+package com.github.seregamorph.maven.test.storage;
+
+import javax.annotation.Nullable;
+
+/**
+ * @author Sergey Chernov
+ */
+public class MinServerProtocolVersionException extends RuntimeException {
+
+    public MinServerProtocolVersionException(String message, @Nullable Integer serverVersion, int minServerVersion) {
+        super(message + ", serverVersion: " + (serverVersion == null ? "<empty>" : serverVersion.toString()) + ", "
+            + "minServerVersion: " + minServerVersion);
+    }
+}

--- a/test-cache-server/src/main/java/com/github/seregamorph/testcacheserver/ServerProtocolVersionInterceptor.java
+++ b/test-cache-server/src/main/java/com/github/seregamorph/testcacheserver/ServerProtocolVersionInterceptor.java
@@ -1,0 +1,19 @@
+package com.github.seregamorph.testcacheserver;
+
+import com.github.seregamorph.maven.test.common.ServerProtocolVersion;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * @author Sergey Chernov
+ */
+public class ServerProtocolVersionInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        response.addHeader(ServerProtocolVersion.HEADER_SERVER_PROTOCOL_VERSION,
+                Integer.toString(ServerProtocolVersion.SERVER_PROTOCOL_VERSION));
+        return true;
+    }
+}

--- a/test-cache-server/src/main/java/com/github/seregamorph/testcacheserver/WebConfiguration.java
+++ b/test-cache-server/src/main/java/com/github/seregamorph/testcacheserver/WebConfiguration.java
@@ -1,0 +1,17 @@
+package com.github.seregamorph.testcacheserver;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * @author Sergey Chernov
+ */
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new ServerProtocolVersionInterceptor());
+    }
+}


### PR DESCRIPTION
Extension first always read from the cache (either local or remote). With this solution we guarantee that server will not be affected with a breaking change as extension will just fail fast.

Related to this breaking change https://github.com/seregamorph/maven-surefire-cached/pull/10