### PR TITLE
#15 Support S3 directly from Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add to the `.mvn/extensions.xml` of your project:
 ```
 This extension will print the cache statistics after the build.
 
-## Configuration
+## Module configuration
 It's possible to define `surefire-cached.json` file for the module. If the file is not found,
 the extension will go thru the parent modules (till root) and try to find it there.
 
@@ -126,7 +126,18 @@ custom artifacts to be cached (separate for surefire and failsafe):
 }
 ```
 
-Sample adoption:
+## Global configuration
+It's possible to define global configuration options. These parameters can be specified in `.mvn/maven.config` as
+default, or in the maven command line. Configuration parameters should be prefixed 
+with `-D` (e.g. `-DcacheExpirationHours=4`). All these parameters are optional and have default value.
+
+Parameters:
+
+| Parameter              | Comment                                                                                      | Default value |
+|------------------------|----------------------------------------------------------------------------------------------|---------------|
+| `cacheExpirationHours` | Time interval in hours for how long the cache entity is valid. Now used only for s3 storage. | 6             |
+
+## Sample adoption:
 * https://github.com/seregamorph/spring-test-smart-context/pull/23
 * https://github.com/seregamorph/rest-api-framework/pull/2
 
@@ -173,6 +184,36 @@ Actuator endpoints are available at http://localhost:8080/actuator, see http://l
 for metrics.
 
 TODO grafana dashboard WiP
+
+## Using S3 from Maven
+It's possible to access S3 directly from Maven build (no HTTP service required).
+
+First you need to use this extension in `.mvn/extensions.xml` (instead of the regular `surefire-cached-extension`):
+```xml
+<extensions>
+    <extension>
+        <groupId>com.github.seregamorph</groupId>
+        <artifactId>surefire-cached-extension-s3</artifactId>
+        <version>0.22-SNAPSHOT</version>
+    </extension>
+</extensions>
+```
+
+Declare `cacheStorageUrl` property as s3 URI to the bucket:
+```shell
+mvn clean verify -DcacheStorageUrl=s3://bucketname
+```
+Other parameters will be obtained from the environment variables (like `AWS_REGION`), system property
+(like `aws.region`) or default local AWS profile.
+
+Depending on the authorization provider these environment variables may be used
+* `AWS_ACCESS_KEY_ID`
+* `AWS_SECRET_KEY_ID`
+
+For the other options (including loading from `~/.aws/credentials`) see
+[AWS documentation](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html)
+
+The entities will be saved in S3 with [cacheExpirationHours](README.md#global-configuration) expiration timeout.
 
 ## Reporting
 The extension generates text and json reports at the end of the build.

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <modules>
         <module>surefire-cached-common</module>
         <module>surefire-cached-extension</module>
+        <module>surefire-cached-extension-s3</module>
     </modules>
 
     <build>
@@ -183,6 +184,11 @@
                 <artifactId>surefire-cached-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.github.seregamorph</groupId>
+                <artifactId>surefire-cached-extension</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>javax.inject</groupId>
@@ -270,6 +276,12 @@
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
                 <version>4.12.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>s3</artifactId>
+                <version>2.31.78</version>
             </dependency>
 
             <!--test-->

--- a/surefire-cached-common/pom.xml
+++ b/surefire-cached-common/pom.xml
@@ -43,5 +43,11 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-parameter-names</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/storage/S3CacheStorage.java
+++ b/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/storage/S3CacheStorage.java
@@ -1,0 +1,82 @@
+package com.github.seregamorph.maven.test.storage;
+
+import com.github.seregamorph.maven.test.common.CacheEntryKey;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.InvalidObjectStateException;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+
+/**
+ * Cache storage for AWS S3.
+ * Can be used directly from Maven extension or in the cache web server.
+ *
+ * @author Sergey Chernov
+ */
+public class S3CacheStorage implements CacheStorage {
+
+    private static final Logger logger = LoggerFactory.getLogger(S3CacheStorage.class);
+
+    private final S3Client s3Client;
+    private final S3CacheStorageConfig config;
+
+    public S3CacheStorage(S3Client s3Client, S3CacheStorageConfig config) {
+        this.s3Client = s3Client;
+        this.config = config;
+    }
+
+    @Nullable
+    @Override
+    public byte[] read(CacheEntryKey cacheEntryKey, String fileName) throws CacheStorageException {
+        String awsKey = cacheEntryKey + "/" + fileName;
+        try {
+            try (ResponseInputStream<GetObjectResponse> object = s3Client.getObject(b -> b.bucket(config.getBucket()).key(awsKey))) {
+                byte[] bytes = IOUtils.toByteArray(object);
+                String expiresString = object.response().expiresString();
+                ZonedDateTime expires = parseExpires(expiresString);
+                if (isExpired(expires)) {
+                    logger.debug("Skipping cache entry {} expired at {}", awsKey, expires);
+                    return null;
+                }
+                return bytes;
+            }
+        } catch (NoSuchKeyException | InvalidObjectStateException e) {
+            return null;
+        } catch (IOException e) {
+            logger.warn("Error while reading from S3 {}", awsKey, e);
+            return null;
+        }
+    }
+
+    protected boolean isExpired(@Nullable ZonedDateTime expires) {
+        return expires != null && expires.isBefore(ZonedDateTime.now());
+    }
+
+    @Override
+    public int write(CacheEntryKey cacheEntryKey, String fileName, byte[] value) throws CacheStorageException {
+        String awsKey = cacheEntryKey + "/" + fileName;
+        Instant expires = Instant.now().plus(config.getExpiration());
+        s3Client.putObject(b -> b.bucket(config.getBucket()).key(awsKey).expires(expires),
+            RequestBody.fromBytes(value));
+        return 0;
+    }
+
+    @Nullable
+    static ZonedDateTime parseExpires(@Nullable String expiresString) {
+        if (expiresString == null || expiresString.isEmpty()) {
+            return null;
+        }
+        return ZonedDateTime.parse(expiresString, RFC_1123_DATE_TIME);
+    }
+}

--- a/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/storage/S3CacheStorageConfig.java
+++ b/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/storage/S3CacheStorageConfig.java
@@ -1,0 +1,34 @@
+package com.github.seregamorph.maven.test.storage;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * @author Sergey Chernov
+ */
+public class S3CacheStorageConfig {
+
+    private final String bucket;
+    private final Duration expiration;
+
+    public S3CacheStorageConfig(String bucket, Duration expiration) {
+        this.bucket = Objects.requireNonNull(bucket, "bucket");
+        this.expiration = Objects.requireNonNull(expiration, "expiration");
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public Duration getExpiration() {
+        return expiration;
+    }
+
+    @Override
+    public String toString() {
+        return "S3CacheStorageConfig{" +
+            "bucket='" + bucket + '\'' +
+            ", expiration=" + expiration +
+            '}';
+    }
+}

--- a/surefire-cached-common/src/test/java/com/github/seregamorph/maven/test/storage/S3CacheStorageTest.java
+++ b/surefire-cached-common/src/test/java/com/github/seregamorph/maven/test/storage/S3CacheStorageTest.java
@@ -1,0 +1,15 @@
+package com.github.seregamorph.maven.test.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+class S3CacheStorageTest {
+
+    @Test
+    void shouldParseExpires() {
+        var expires = S3CacheStorage.parseExpires("Sat, 31 May 2025 01:02:03 GMT");
+        assertEquals(ZonedDateTime.parse("2025-05-31T01:02:03Z"), expires);
+    }
+}

--- a/surefire-cached-extension-s3/pom.xml
+++ b/surefire-cached-extension-s3/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.seregamorph</groupId>
+        <artifactId>maven-surefire-cached</artifactId>
+        <version>0.22-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>surefire-cached-extension-s3</artifactId>
+    <packaging>jar</packaging>
+    <name>surefire-cached-extension-s3</name>
+
+    <description>
+        Surefire Cached Extension that directly writes to an S3 storage
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.seregamorph</groupId>
+            <artifactId>surefire-cached-extension</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/surefire-cached-extension-s3/src/main/java/com/github/seregamorph/maven/test/extension/S3CacheStorageProvider.java
+++ b/surefire-cached-extension-s3/src/main/java/com/github/seregamorph/maven/test/extension/S3CacheStorageProvider.java
@@ -1,0 +1,51 @@
+package com.github.seregamorph.maven.test.extension;
+
+import com.github.seregamorph.maven.test.extension.spi.CacheStorageProvider;
+import com.github.seregamorph.maven.test.storage.CacheStorage;
+import com.github.seregamorph.maven.test.storage.S3CacheStorage;
+import com.github.seregamorph.maven.test.storage.S3CacheStorageConfig;
+import com.github.seregamorph.maven.test.util.PropertySource;
+import java.net.URI;
+import java.time.Duration;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+/**
+ * @author Sergey Chernov
+ */
+public class S3CacheStorageProvider implements CacheStorageProvider {
+
+    private static final String S3_PREFIX = "s3://";
+
+    @Override
+    public boolean supportsCacheStorageUrl(String cacheStorageUrl) {
+        return cacheStorageUrl.startsWith(S3_PREFIX);
+    }
+
+    @Override
+    public CacheStorage createCacheStorage(String cacheStorageUrl, PropertySource propertySource) {
+        S3ClientBuilder s3ClientBuilder = S3Client.builder();
+        String s3EndpointOverride = propertySource.getProperty("s3EndpointOverride", null);
+        if (s3EndpointOverride != null) {
+            // for localstack compatibility
+            s3ClientBuilder.serviceConfiguration(S3Configuration.builder()
+                .pathStyleAccessEnabled(true)
+                .build());
+            s3ClientBuilder.endpointOverride(URI.create(s3EndpointOverride));
+        }
+        S3Client s3Client = s3ClientBuilder.build();
+
+        String bucket = cacheStorageUrl.substring(S3_PREFIX.length());
+        if (bucket.isEmpty()) {
+            throw new IllegalArgumentException("S3 bucket is empty: " + cacheStorageUrl);
+        }
+        if (bucket.endsWith("/")) {
+            throw new IllegalArgumentException("S3 bucket should not end with '/': " + cacheStorageUrl);
+        }
+        Duration expiration = Duration.ofHours(Integer.parseInt(
+            propertySource.getProperty("cacheExpirationHours", "6")));
+        S3CacheStorageConfig s3CacheStorageConfig = new S3CacheStorageConfig(bucket, expiration);
+        return new S3CacheStorage(s3Client, s3CacheStorageConfig);
+    }
+}

--- a/surefire-cached-extension-s3/src/main/resources/META-INF/services/com.github.seregamorph.maven.test.extension.spi.CacheStorageProvider
+++ b/surefire-cached-extension-s3/src/main/resources/META-INF/services/com.github.seregamorph.maven.test.extension.spi.CacheStorageProvider
@@ -1,0 +1,1 @@
+com.github.seregamorph.maven.test.extension.S3CacheStorageProvider

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/CachedTestLifecycleParticipant.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/CachedTestLifecycleParticipant.java
@@ -10,6 +10,7 @@ import com.github.seregamorph.maven.test.core.TaskOutcome;
 import com.github.seregamorph.maven.test.storage.CacheServiceMetrics;
 import com.github.seregamorph.maven.test.storage.CacheStorage;
 import com.github.seregamorph.maven.test.storage.HttpCacheStorage;
+import com.github.seregamorph.maven.test.storage.S3CacheStorage;
 import com.github.seregamorph.maven.test.util.JsonSerializers;
 import com.github.seregamorph.maven.test.util.MoreFileUtils;
 import java.io.File;
@@ -114,7 +115,8 @@ public class CachedTestLifecycleParticipant extends AbstractMavenLifecyclePartic
     }
 
     private boolean isLogStorageMetrics(CacheStorage cacheStorage) {
-        return cacheStorage instanceof HttpCacheStorage;
+        return cacheStorage instanceof HttpCacheStorage
+            || cacheStorage instanceof S3CacheStorage;
     }
 
     private void saveJsonReport(MavenSession session, Map<PluginName, Map<TaskOutcome, AggResult>> pluginResults) {

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/spi/CacheStorageProvider.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/spi/CacheStorageProvider.java
@@ -1,0 +1,14 @@
+package com.github.seregamorph.maven.test.extension.spi;
+
+import com.github.seregamorph.maven.test.storage.CacheStorage;
+import com.github.seregamorph.maven.test.util.PropertySource;
+
+/**
+ * @author Sergey Chernov
+ */
+public interface CacheStorageProvider {
+
+    boolean supportsCacheStorageUrl(String cacheStorageUrl);
+
+    CacheStorage createCacheStorage(String cacheStorageUrl, PropertySource propertySource);
+}


### PR DESCRIPTION
This PR adds support of S3 storage.
To use S3, specify the `-DcacheStorageUrl=s3://bucketname` in the maven command:
```shell
mvn clean verify -DcacheStorageUrl=s3://bucketname
```
Also another extension should be used instead of the regular `surefire-cached-extension`:
```xml
<extensions>
    <extension>
        <groupId>com.github.seregamorph</groupId>
        <artifactId>surefire-cached-extension-s3</artifactId>
        <version>0.22-SNAPSHOT</version>
    </extension>
</extensions>
```
(that's because this `-s3` extension has lots of heavy-weight AWS dependencies)

Note that it will also require environment variables to properly set up S3 client:
```
export AWS_REGION=us-east-1
export AWS_ACCESS_KEY_ID=000000000000
export AWS_SECRET_ACCESS_KEY=000000000000
```
Environment variables is not the only possible, see the [AWS documentation](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html) for all available options to authenticate and configure the client.