### PR TITLE
Fix #23: diagnose wrong extension setup

### DIFF
--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/CachedMavenPluginManager.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/CachedMavenPluginManager.java
@@ -52,6 +52,8 @@ public class CachedMavenPluginManager implements MavenPluginManager {
     ) {
         this.defaultMavenPluginManagerProvider = defaultMavenPluginManagerProvider;
         this.testTaskCacheHelper = testTaskCacheHelper;
+
+        testTaskCacheHelper.notifyPluginManagerInstantiated();
     }
 
     @Override

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/TestTaskCacheHelper.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/TestTaskCacheHelper.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javax.inject.Singleton;
 import org.apache.maven.artifact.Artifact;
@@ -34,6 +35,8 @@ import org.apache.maven.project.MavenProject;
  */
 @Singleton
 public class TestTaskCacheHelper {
+
+    private final AtomicBoolean pluginManagerInstantiated = new AtomicBoolean();
 
     private FileHashCache fileHashCache;
     private SortedSet<GroupArtifactId> modules;
@@ -64,6 +67,14 @@ public class TestTaskCacheHelper {
         metrics = null;
         modules = null;
         fileHashCache = null;
+    }
+
+    void notifyPluginManagerInstantiated() {
+        pluginManagerInstantiated.set(true);
+    }
+
+    boolean wasPluginManagerInstantiated() {
+        return pluginManagerInstantiated.get();
     }
 
     public CacheServiceMetrics getMetrics() {


### PR DESCRIPTION
Fixes #23

Context: there are at least 3 ways to add the extension:
* via `pom.xml` `build/extensions` tag
* via `pom.xml` plugins with `<extensions>true</extensions>`
* via `.mvn/extensions.xml` - only this works

In all three scenarios the `CachedTestLifecycleParticipant` is working, but the `CachedMavenPluginManager` is applied only when the extension is set up via the `.mvn/extensions.xml`. To avoid misleading empty test execution report this self diagnostic is added (prints warning, does not break the build).