### PR TITLE
List flaky failures

### DIFF
--- a/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/FlakyFailure.java
+++ b/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/FlakyFailure.java
@@ -1,0 +1,36 @@
+package com.github.seregamorph.maven.test.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * @author Sergey Chernov
+ */
+@JsonIgnoreProperties(ignoreUnknown = true) // for forward compatibility
+public class FlakyFailure {
+
+    private final String testClassName;
+    private final String testName;
+
+    @JsonCreator
+    public FlakyFailure(String testClassName, String testName) {
+        this.testClassName = testClassName;
+        this.testName = testName;
+    }
+
+    public String getTestClassName() {
+        return testClassName;
+    }
+
+    public String getTestName() {
+        return testName;
+    }
+
+    @Override
+    public String toString() {
+        return "FlakyFailure{" +
+            "testClassName='" + testClassName + '\'' +
+            ", testName='" + testName + '\'' +
+            '}';
+    }
+}

--- a/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/TestTaskOutput.java
+++ b/surefire-cached-common/src/main/java/com/github/seregamorph/maven/test/common/TestTaskOutput.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -30,9 +32,9 @@ public final class TestTaskOutput {
     private final int totalFailures;
     @Nullable
     private final String failureMessage;
-    private final int totalTestcaseFlakyErrors;
-    private final int totalTestcaseFlakyFailures;
-    private final int totalTestcaseErrors;
+    private final List<FlakyFailure> testcaseFlakyErrors;
+    private final List<FlakyFailure> testcaseFlakyFailures;
+    private final List<FlakyFailure> testcaseErrors;
     // alias -> artifact
     private final Map<String, OutputArtifact> artifacts;
 
@@ -47,9 +49,9 @@ public final class TestTaskOutput {
         int totalFailures,
         @Nullable
         String failureMessage,
-        int totalTestcaseFlakyErrors,
-        int totalTestcaseFlakyFailures,
-        int totalTestcaseErrors,
+        List<FlakyFailure> testcaseFlakyErrors,
+        List<FlakyFailure> testcaseFlakyFailures,
+        List<FlakyFailure> testcaseErrors,
         Map<String, OutputArtifact> artifacts
     ) {
         this.startTime = startTime;
@@ -60,9 +62,9 @@ public final class TestTaskOutput {
         this.totalErrors = totalErrors;
         this.totalFailures = totalFailures;
         this.failureMessage = failureMessage;
-        this.totalTestcaseFlakyErrors = totalTestcaseFlakyErrors;
-        this.totalTestcaseFlakyFailures = totalTestcaseFlakyFailures;
-        this.totalTestcaseErrors = totalTestcaseErrors;
+        this.testcaseFlakyErrors = testcaseFlakyErrors == null ? Collections.emptyList() : testcaseFlakyErrors;
+        this.testcaseFlakyFailures = testcaseFlakyFailures  == null ? Collections.emptyList() : testcaseFlakyFailures;
+        this.testcaseErrors = testcaseErrors  == null ? Collections.emptyList() : testcaseErrors;
         this.artifacts = artifacts;
     }
 
@@ -99,16 +101,16 @@ public final class TestTaskOutput {
         return failureMessage;
     }
 
-    public int getTotalTestcaseFlakyErrors() {
-        return totalTestcaseFlakyErrors;
+    public List<FlakyFailure> getTestcaseFlakyErrors() {
+        return testcaseFlakyErrors;
     }
 
-    public int getTotalTestcaseFlakyFailures() {
-        return totalTestcaseFlakyFailures;
+    public List<FlakyFailure> getTestcaseFlakyFailures() {
+        return testcaseFlakyFailures;
     }
 
-    public int getTotalTestcaseErrors() {
-        return totalTestcaseErrors;
+    public List<FlakyFailure> getTestcaseErrors() {
+        return testcaseErrors;
     }
 
     public Map<String, OutputArtifact> getArtifacts() {
@@ -122,7 +124,7 @@ public final class TestTaskOutput {
 
     @JsonIgnore
     public boolean hasFlakyFailures() {
-        return totalTestcaseFlakyErrors > 0 || totalTestcaseFlakyFailures > 0;
+        return !testcaseFlakyErrors.isEmpty() || !testcaseFlakyFailures.isEmpty();
     }
 
     @Override
@@ -136,9 +138,9 @@ public final class TestTaskOutput {
             ", totalErrors=" + totalErrors +
             ", totalFailures=" + totalFailures +
             ", failureMessage='" + failureMessage + '\'' +
-            ", totalTestcaseFlakyErrors=" + totalTestcaseFlakyErrors +
-            ", totalTestcaseFlakyFailures=" + totalTestcaseFlakyFailures +
-            ", totalTestcaseErrors=" + totalTestcaseErrors +
+            ", testcaseFlakyErrors=" + testcaseFlakyErrors +
+            ", testcaseFlakyFailures=" + testcaseFlakyFailures +
+            ", testcaseErrors=" + testcaseErrors +
             ", artifacts=" + artifacts +
             '}';
     }

--- a/surefire-cached-common/src/test/java/com/github/seregamorph/maven/test/common/TestTaskOutputTest.java
+++ b/surefire-cached-common/src/test/java/com/github/seregamorph/maven/test/common/TestTaskOutputTest.java
@@ -7,6 +7,7 @@ import com.github.seregamorph.maven.test.util.JsonSerializers;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
@@ -24,9 +25,9 @@ class TestTaskOutputTest {
             0,
             0,
             "failure",
-            0,
-            0,
-            0,
+            List.of(),
+            List.of(),
+            List.of(),
             Map.of(
                 "jacoco",
                 new OutputArtifact(
@@ -47,9 +48,9 @@ class TestTaskOutputTest {
         assertEquals(testTestOutput.getTotalErrors(), restored.getTotalErrors());
         assertEquals(testTestOutput.getTotalFailures(), restored.getTotalFailures());
         assertEquals(testTestOutput.getFailureMessage(), restored.getFailureMessage());
-        assertEquals(testTestOutput.getTotalTestcaseFlakyErrors(), restored.getTotalTestcaseFlakyErrors());
-        assertEquals(testTestOutput.getTotalTestcaseFlakyFailures(), restored.getTotalTestcaseFlakyFailures());
-        assertEquals(testTestOutput.getTotalTestcaseErrors(), restored.getTotalTestcaseErrors());
+        assertEquals(testTestOutput.getTestcaseFlakyErrors(), restored.getTestcaseFlakyErrors());
+        assertEquals(testTestOutput.getTestcaseFlakyFailures(), restored.getTestcaseFlakyFailures());
+        assertEquals(testTestOutput.getTestcaseErrors(), restored.getTestcaseErrors());
         assertEquals(testTestOutput.getArtifacts().get("jacoco").getFileName(),
             restored.getArtifacts().get("jacoco").getFileName());
         assertEquals(testTestOutput.getArtifacts().get("jacoco").getFiles(),
@@ -91,9 +92,9 @@ class TestTaskOutputTest {
         assertEquals(100, restored.getTotalTests());
         assertEquals(0, restored.getTotalErrors());
         assertEquals(0, restored.getTotalFailures());
-        assertEquals(0, restored.getTotalTestcaseFlakyErrors());
-        assertEquals(0, restored.getTotalTestcaseFlakyFailures());
-        assertEquals(0, restored.getTotalTestcaseErrors());
+        assertEquals(List.of(), restored.getTestcaseFlakyErrors());
+        assertEquals(List.of(), restored.getTestcaseFlakyFailures());
+        assertEquals(List.of(), restored.getTestcaseErrors());
         assertEquals("jacoco.exec",
             restored.getArtifacts().get("jacoco").getFileName());
         assertEquals(1,
@@ -116,8 +117,17 @@ class TestTaskOutputTest {
               "totalTests" : 100,
               "totalErrors" : 0,
               "totalFailures" : 0,
-              "totalTestcaseFlakyErrors": 1,
-              "totalTestcaseErrors": 2,
+              "testcaseFlakyErrors": [{
+                  "testClassName": "flaky",
+                  "testName": "failure"
+              }],
+              "testcaseErrors": [{
+                  "testClassName": "flaky",
+                  "testName": "error1"
+              }, {
+                  "testClassName": "flaky",
+                  "testName": "error2"
+              }],
               "newField": {
                 "sub": "value"
               },
@@ -140,9 +150,11 @@ class TestTaskOutputTest {
         assertEquals(100, restored.getTotalTests());
         assertEquals(0, restored.getTotalErrors());
         assertEquals(0, restored.getTotalFailures());
-        assertEquals(1, restored.getTotalTestcaseFlakyErrors());
-        assertEquals(0, restored.getTotalTestcaseFlakyFailures());
-        assertEquals(2, restored.getTotalTestcaseErrors());
+        assertEquals("[FlakyFailure{testClassName='flaky', testName='failure'}]",
+            restored.getTestcaseFlakyErrors().toString());
+        assertEquals(List.of(), restored.getTestcaseFlakyFailures());
+        assertEquals("[FlakyFailure{testClassName='flaky', testName='error1'}, FlakyFailure{testClassName='flaky', testName='error2'}]",
+            restored.getTestcaseErrors().toString());
         assertEquals("jacoco.exec",
             restored.getArtifacts().get("jacoco").getFileName());
         assertEquals(1,

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/core/TaskOutcome.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/core/TaskOutcome.java
@@ -8,7 +8,12 @@ import javax.annotation.Nullable;
  */
 public enum TaskOutcome {
 
-    SKIPPED_CACHE("serial time", true),
+    SKIPPED_CACHE("serial time", true) {
+        @Override
+        public String message(TestTaskOutput testTaskOutput) {
+            return null;
+        }
+    },
     SUCCESS("serial time", true) {
         @Override
         public String message(TestTaskOutput testTaskOutput) {
@@ -19,9 +24,9 @@ public enum TaskOutcome {
     FLAKY("serial time", true) {
         @Override
         public String message(TestTaskOutput testTaskOutput) {
-            return "(flaky errors " + testTaskOutput.getTotalTestcaseFlakyErrors()
-                + ", flaky failures " + testTaskOutput.getTotalTestcaseFlakyFailures()
-                + ", failures " + testTaskOutput.getTotalTestcaseErrors() + ")";
+            return "(flaky errors " + testTaskOutput.getTestcaseFlakyErrors().size()
+                + ", flaky failures " + testTaskOutput.getTestcaseFlakyFailures().size()
+                + ", failures " + testTaskOutput.getTestcaseErrors().size() + ")";
         }
     },
     FAILED("serial time", true) {
@@ -31,7 +36,12 @@ public enum TaskOutcome {
                 + ", failures " + testTaskOutput.getTotalFailures() + ")";
         }
     },
-    EMPTY("serial time", false),
+    EMPTY("serial time", false) {
+        @Override
+        public String message(TestTaskOutput testTaskOutput) {
+            return null;
+        }
+    },
     FROM_CACHE("serial time saved", true) {
         @Override
         public String message(TestTaskOutput testTaskOutput) {
@@ -60,7 +70,5 @@ public enum TaskOutcome {
     }
 
     @Nullable
-    public String message(TestTaskOutput testTaskOutput) {
-        return null;
-    }
+    public abstract String message(TestTaskOutput testTaskOutput);
 }

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/core/Testcase.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/core/Testcase.java
@@ -1,0 +1,31 @@
+package com.github.seregamorph.maven.test.core;
+
+/**
+ * @author Sergey Chernov
+ */
+public class Testcase {
+
+    private final String classname;
+    private final String name;
+
+    Testcase(String classname, String name) {
+        this.classname = classname;
+        this.name = name;
+    }
+
+    public String getClassname() {
+        return classname;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "Testcase{" +
+            "classname='" + classname + '\'' +
+            ", name='" + name + '\'' +
+            '}';
+    }
+}

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/core/TestcaseFailure.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/core/TestcaseFailure.java
@@ -1,0 +1,38 @@
+package com.github.seregamorph.maven.test.core;
+
+/**
+ * @author Sergey Chernov
+ */
+public class TestcaseFailure {
+
+    private final Testcase testcase;
+    private final String type;
+    private final String message;
+
+    TestcaseFailure(Testcase testcase, String type, String message) {
+        this.testcase = testcase;
+        this.type = type;
+        this.message = message;
+    }
+
+    public Testcase getTestcase() {
+        return testcase;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
+        return "TestcaseFailure{" +
+            "testcase=" + testcase +
+            ", type='" + type + '\'' +
+            ", message='" + message + '\'' +
+            '}';
+    }
+}

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/AbstractCachedSurefireMojo.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/AbstractCachedSurefireMojo.java
@@ -87,7 +87,9 @@ abstract class AbstractCachedSurefireMojo extends AbstractMojo {
     private void reportCachedExecution(TaskOutcome result, TestTaskOutput testTaskOutput, int deletedCacheEntries) {
         GroupArtifactId groupArtifactId = getGroupArtifactId(project);
         ModuleTestResult moduleTestResult = new ModuleTestResult(groupArtifactId, result,
-            testTaskOutput.getTotalTimeSeconds(), deletedCacheEntries);
+            testTaskOutput.getTotalTimeSeconds(), deletedCacheEntries,
+            testTaskOutput.getTestcaseFlakyErrors(), testTaskOutput.getTestcaseFlakyFailures(),
+            testTaskOutput.getTestcaseErrors());
         cacheReport.addExecutionResult(groupArtifactId, pluginName, moduleTestResult);
 
         String message = result.message(testTaskOutput);
@@ -167,7 +169,7 @@ abstract class AbstractCachedSurefireMojo extends AbstractMojo {
             if (testTaskOutput.hasFailures()) {
                 log.warn("Tests failed, not storing to cache. See {}", reportsDirectory);
                 reportCachedExecution(TaskOutcome.FAILED, testTaskOutput);
-            } else if (testTaskOutput.getTotalTestcaseErrors() > 0 ||
+            } else if (!testTaskOutput.getTestcaseErrors().isEmpty() ||
                 !cacheIfTestcaseFlakyErrors && testTaskOutput.hasFlakyFailures()) {
                 log.warn("Tests have testcase failures or flaky errors, not storing to cache. See {}",
                     reportsDirectory);

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/IntegrationTestCachedMojo.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/IntegrationTestCachedMojo.java
@@ -1,12 +1,20 @@
 package com.github.seregamorph.maven.test.extension;
 
+import static com.github.seregamorph.maven.test.extension.SurefireCachedMojo.formatFailures;
+
+import com.github.seregamorph.maven.test.common.FlakyFailure;
 import com.github.seregamorph.maven.test.common.PluginName;
 import com.github.seregamorph.maven.test.common.TestTaskOutput;
 import com.github.seregamorph.maven.test.core.FailsafeSummaryReport;
+import com.github.seregamorph.maven.test.core.TestSuiteReport;
 import com.github.seregamorph.maven.test.util.ReflectionUtils;
 import java.io.File;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.Mojo;
@@ -37,14 +45,30 @@ class IntegrationTestCachedMojo extends AbstractCachedSurefireMojo {
         if (!summaryFile.exists()) {
             return new TestTaskOutput(startTime, endTime, totalTimeSeconds,
                 BigDecimal.ZERO, 0, 0, 0, null,
-                0, 0, 0,
+                Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                 new TreeMap<>());
         }
 
         FailsafeSummaryReport report = FailsafeSummaryReport.fromFile(summaryFile);
+        Map<File, TestSuiteReport> testReports = TestSuiteReport.fromDirectory(reportsDirectory);
+        List<FlakyFailure> testcaseFlakyErrors = new ArrayList<>();
+        List<FlakyFailure> testcaseFlakyFailures = new ArrayList<>();
+        List<FlakyFailure> testcaseErrors = new ArrayList<>();
+        for (Map.Entry<File, TestSuiteReport> entry : testReports.entrySet()) {
+            TestSuiteReport testSuiteSummary = entry.getValue();
+            testcaseFlakyErrors.addAll(formatFailures(testSuiteSummary.testcaseFlakyErrors()));
+            testcaseFlakyFailures.addAll(formatFailures(testSuiteSummary.testcaseFlakyFailures()));
+            testcaseErrors.addAll(formatFailures(testSuiteSummary.testcaseErrors()));
+        }
+
+        if (report.getFlakes() > 0 && testcaseFlakyErrors.isEmpty()) {
+            // this can happen e.g. if TEST-*.xml reports are not enabled
+            testcaseFlakyErrors.add(new FlakyFailure("failsafe-summary.xml", "flakes"));
+        }
+
         return new TestTaskOutput(startTime, endTime, totalTimeSeconds,
             totalTimeSeconds, report.getCompleted(),
             report.getErrors(), report.getFailures(), report.getFailureMessage(),
-            report.getFlakes(), 0, 0, new TreeMap<>());
+            testcaseFlakyErrors, testcaseFlakyFailures, testcaseErrors, new TreeMap<>());
     }
 }

--- a/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/ModuleTestResult.java
+++ b/surefire-cached-extension/src/main/java/com/github/seregamorph/maven/test/extension/ModuleTestResult.java
@@ -1,8 +1,10 @@
 package com.github.seregamorph.maven.test.extension;
 
+import com.github.seregamorph.maven.test.common.FlakyFailure;
 import com.github.seregamorph.maven.test.common.GroupArtifactId;
 import com.github.seregamorph.maven.test.core.TaskOutcome;
 import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * @author Sergey Chernov
@@ -13,17 +15,26 @@ public final class ModuleTestResult {
     private final TaskOutcome result;
     private final BigDecimal totalTimeSeconds;
     private final int deletedCacheEntries;
+    private final List<FlakyFailure> testcaseFlakyErrors;
+    private final List<FlakyFailure> testcaseFlakyFailures;
+    private final List<FlakyFailure> testcaseErrors;
 
     public ModuleTestResult(
         GroupArtifactId groupArtifactId,
         TaskOutcome result,
         BigDecimal totalTimeSeconds,
-        int deletedCacheEntries
+        int deletedCacheEntries,
+        List<FlakyFailure> testcaseFlakyErrors,
+        List<FlakyFailure> testcaseFlakyFailures,
+        List<FlakyFailure> testcaseErrors
     ) {
         this.groupArtifactId = groupArtifactId;
         this.result = result;
         this.totalTimeSeconds = totalTimeSeconds;
         this.deletedCacheEntries = deletedCacheEntries;
+        this.testcaseFlakyErrors = testcaseFlakyErrors;
+        this.testcaseFlakyFailures = testcaseFlakyFailures;
+        this.testcaseErrors = testcaseErrors;
     }
 
     public GroupArtifactId getGroupArtifactId() {
@@ -42,6 +53,18 @@ public final class ModuleTestResult {
         return deletedCacheEntries;
     }
 
+    public List<FlakyFailure> getTestcaseFlakyErrors() {
+        return testcaseFlakyErrors;
+    }
+
+    public List<FlakyFailure> getTestcaseFlakyFailures() {
+        return testcaseFlakyFailures;
+    }
+
+    public List<FlakyFailure> getTestcaseErrors() {
+        return testcaseErrors;
+    }
+
     @Override
     public String toString() {
         return "ModuleTestResult{" +
@@ -49,6 +72,9 @@ public final class ModuleTestResult {
             ", result=" + result +
             ", totalTimeSeconds=" + totalTimeSeconds +
             ", deletedCacheEntries=" + deletedCacheEntries +
+            ", testcaseFlakyErrors=" + testcaseFlakyErrors +
+            ", testcaseFlakyFailures=" + testcaseFlakyFailures +
+            ", testcaseErrors=" + testcaseErrors +
             '}';
     }
 }

--- a/surefire-cached-extension/src/test/java/com/github/seregamorph/maven/test/core/TestSuiteReportTest.java
+++ b/surefire-cached-extension/src/test/java/com/github/seregamorph/maven/test/core/TestSuiteReportTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class TestSuiteReportTest {
@@ -19,8 +20,9 @@ class TestSuiteReportTest {
         assertEquals(1, testSuiteReport.tests());
         assertEquals(0, testSuiteReport.errors());
         assertEquals(0, testSuiteReport.failures());
-        assertEquals(0, testSuiteReport.testcaseFlakyErrors());
-        assertEquals(0, testSuiteReport.testcaseErrors());
+        assertEquals(List.of(), testSuiteReport.testcaseFlakyErrors());
+        assertEquals(List.of(), testSuiteReport.testcaseFlakyFailures());
+        assertEquals(List.of(), testSuiteReport.testcaseErrors());
     }
 
     @Test
@@ -33,9 +35,9 @@ class TestSuiteReportTest {
         assertEquals(1, testSuiteReport.tests());
         assertEquals(0, testSuiteReport.errors());
         assertEquals(0, testSuiteReport.failures());
-        assertEquals(0, testSuiteReport.testcaseFlakyErrors());
-        assertEquals(0, testSuiteReport.testcaseFlakyFailures());
-        assertEquals(0, testSuiteReport.testcaseErrors());
+        assertEquals(List.of(), testSuiteReport.testcaseFlakyErrors());
+        assertEquals(List.of(), testSuiteReport.testcaseFlakyFailures());
+        assertEquals(List.of(), testSuiteReport.testcaseErrors());
     }
 
     @Test
@@ -48,9 +50,9 @@ class TestSuiteReportTest {
         assertEquals(1, testSuiteReport.tests());
         assertEquals(0, testSuiteReport.errors());
         assertEquals(0, testSuiteReport.failures());
-        assertEquals(1, testSuiteReport.testcaseFlakyErrors());
-        assertEquals(0, testSuiteReport.testcaseFlakyFailures());
-        assertEquals(1, testSuiteReport.testcaseErrors());
+        assertEquals("[TestcaseFailure{testcase=Testcase{classname='com.github.seregamorph.testsmartcontext.demo.FlakyTest', name='testGetSubscriptionId_MicroserviceEnabled'}, type='org.grpcmock.exception.GrpcMockException', message='failed to start gRPC Mock server'}]", testSuiteReport.testcaseFlakyErrors().toString());
+        assertEquals(List.of(), testSuiteReport.testcaseFlakyFailures());
+        assertEquals("[TestcaseFailure{testcase=Testcase{classname='com.github.seregamorph.testsmartcontext.demo.FlakyTest', name=''}, type='org.grpcmock.exception.GrpcMockException', message='failed to start gRPC Mock server'}]", testSuiteReport.testcaseErrors().toString());
     }
 
     @Test
@@ -63,9 +65,11 @@ class TestSuiteReportTest {
         assertEquals(1, testSuiteReport.tests());
         assertEquals(0, testSuiteReport.errors());
         assertEquals(0, testSuiteReport.failures());
-        assertEquals(0, testSuiteReport.testcaseFlakyErrors());
-        assertEquals(1, testSuiteReport.testcaseFlakyFailures());
-        assertEquals(0, testSuiteReport.testcaseErrors());
+        assertEquals(List.of(), testSuiteReport.testcaseFlakyErrors());
+        assertEquals("[TestcaseFailure{testcase=Testcase{classname='projects.pt.server.architecture.transactional.TransactionalMethodsCallersArchTest', name='transactionalMethods_shouldNotSelfCall'}, type='java.lang.AssertionError', message='Architecture Violation [Priority: MEDIUM] - Rule 'methods that annotated with @Transactional should be public and should not be final and should not be static and should overrides only an interface method if any and should not has class constructor direct calls (only via DI), because this is required to manage transactions with PROXY advice mode' was violated (1 times):\n"
+            + "Constructor Class <com.miro.domain.OrganizationDataDeleters$AllTablesOrganizationDataDeleter> is being called.\n"
+            + "Constructor <com.miro.domain.OrganizationDataDeleters.<init>(java.util.List)> calls constructor <com.miro.domain.OrganizationDataDeleters$AllTablesOrganizationDataDeleter.<init>(java.util.List)> in (OrganizationDataDeleters.kt:16)'}]", testSuiteReport.testcaseFlakyFailures().toString());
+        assertEquals(List.of(), testSuiteReport.testcaseErrors());
     }
 
     private static File getResourceFile(String name) {


### PR DESCRIPTION
Extension recognizes flaky test failures to avoid caching such executions. The updated implementation now also includes these flaky test lists to generated JSON reports to allow analysis.